### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,9 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
 name: Publish release
+permissions:
+  contents: read
+  packages: write
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/BrowserStackCE/browserstack-side-runner/security/code-scanning/1](https://github.com/BrowserStackCE/browserstack-side-runner/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Since the workflow involves publishing a package to npm, it likely requires `contents: read` to access the repository's contents and `packages: write` to publish the package. These permissions will be explicitly defined to limit the scope of the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
