### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-beta-release-publish.yml
+++ b/.github/workflows/npm-beta-release-publish.yml
@@ -3,6 +3,9 @@
 
 name: Publish beta release
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [prereleased]


### PR DESCRIPTION
Potential fix for [https://github.com/BrowserStackCE/browserstack-side-runner/security/code-scanning/2](https://github.com/BrowserStackCE/browserstack-side-runner/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily interacts with npm and does not modify repository contents, the `contents: read` permission is sufficient. This permission allows the workflow to read repository contents without granting write access.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `publish-npm` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
