### PR TITLE
Fixing ES issues and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 package-lock.json
 semgrep.sarif
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/BrowserStackCE/browserstack-side-runner.git"
   },
-  "version": "2.2.2",
+  "version": "2.3.0",
   "main": "index.mjs",
   "homepage": "https://github.com/BrowserStackCE/browserstack-side-runner#readme",
   "scripts": {
@@ -12,6 +12,9 @@
   },
   "bin": {
     "browserstack-side-runner": "index.mjs"
+  },
+  "engines": {
+    "node": ">=18"
   },
   "author": "",
   "license": "ISC",
@@ -21,18 +24,18 @@
     "@seleniumhq/code-export-javascript-mocha": "^4.0.0-alpha.4",
     "@seleniumhq/side-code-export": "^4.0.0-alpha.3",
     "@seleniumhq/side-utils": "^3.17.2",
-    "browserstack-node-sdk": "^1.32.0",
+    "browserstack-node-sdk": "^1.40.8",
     "cli-logger": "^0.5.40",
     "commander": "^8.0.0",
     "cross-spawn": "^7.0.3",
     "dotenv": "^16.0.3",
-    "glob": "^11.0.3",
+    "glob": "^10.4.5",
     "js-yaml": "^4.1.0",
     "mocha": "^8.4.0",
     "mocha-multi-reporters": "^1.5.1",
     "rfdc": "^1.3.0",
-    "rimraf": "^6.0.1",
+    "rimraf": "^5.0.9",
     "sanitize-filename": "^1.6.3",
-    "selenium-webdriver": "^4.1.1"
+    "selenium-webdriver": "^4.5.0"
   }
 }


### PR DESCRIPTION
Issues fixed for glob, rimraf
Adding support for node >=18.20
Picks up the sdk directly from local install rather than potential globally installed version