### PR TITLE
SDK path on NPM fix

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -48,14 +48,15 @@ rimrafSync(options.buildFolderPath)
 fs.mkdirSync(options.buildFolderPath);
 
 function readFile(filename) {
-  return JSON.parse(
-    fs.readFileSync(
-      path.join(
-        '.',
-        sanitize(filename)
-      )
-    )
-  )
+  // Resolve absolute and relative paths correctly and avoid sanitizing directory separators.
+  const resolved = path.isAbsolute(filename)
+    ? filename
+    : path.resolve(process.cwd(), filename)
+  // Only sanitize the filename itself, preserving the original directory.
+  const dir = path.dirname(resolved)
+  const base = sanitize(path.basename(resolved))
+  const finalPath = path.join(dir, base)
+  return JSON.parse(fs.readFileSync(finalPath, 'utf8'))
 }
 
 function normalizeProject(project) {
@@ -92,19 +93,54 @@ if (options.outputFormat && options.outputFile)
   reporter = ['--reporter', options.outputFormat, '--reporter-options', 'output=' + options.outputFile]
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const browserstackSdkPath = path.join(__dirname, 'node_modules', '.bin', 'browserstack-node-sdk');
 const sideRunnerNodeModules = path.join(__dirname, 'node_modules');
 
-const testSuiteProcess = spawn.sync(browserstackSdkPath, ['mocha', '_generated', '--timeouts', options.testTimeout, '-g', options.filter, '--browserstack.config', options.browserstackConfig, ...reporter], { 
-  stdio: 'inherit', 
-  env: { 
-    ...process.env, 
-    testTimeout: options.testTimeout,
-    NODE_PATH: `${sideRunnerNodeModules}${path.delimiter}${process.env.NODE_PATH || ''}`
-  } 
-});
+// Resolve BrowserStack SDK binary robustly with fallbacks
+const sdkCandidates = [
+  path.join(__dirname, 'node_modules', '.bin', 'browserstack-node-sdk'),
+  path.join(process.cwd(), 'node_modules', '.bin', 'browserstack-node-sdk'),
+  // Fall back to letting the OS PATH resolve it (e.g., project-level node_modules/.bin)
+  'browserstack-node-sdk'
+]
+const sdkBin = sdkCandidates.find(p => {
+  try {
+    // If candidate is a bare command (no path separators), let it pass
+    if (!p.includes(path.sep)) return true
+    return fs.existsSync(p)
+  } catch {
+    return false
+  }
+}) || 'browserstack-node-sdk'
+
+if (options.debug) {
+  log.debug(`Using BrowserStack SDK binary: ${sdkBin}`)
+}
+
+let testSuiteProcess
+try {
+  testSuiteProcess = spawn.sync(
+    sdkBin,
+    ['mocha', '_generated', '--timeouts', String(options.testTimeout), '-g', options.filter, '--browserstack.config', options.browserstackConfig, ...reporter],
+    {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        testTimeout: options.testTimeout,
+        NODE_PATH: `${sideRunnerNodeModules}${path.delimiter}${process.env.NODE_PATH || ''}`
+      }
+    }
+  )
+} catch (err) {
+  log.error(`Failed to start BrowserStack SDK at "${sdkBin}": ${err.message}`)
+  exit(1)
+}
+
+if (testSuiteProcess.error) {
+  log.error(`Failed to start BrowserStack SDK at "${sdkBin}": ${testSuiteProcess.error.message}`)
+  exit(1)
+}
 
 if (!options.debug) {
   rimrafSync(options.buildFolderPath)
 }
-exit(testSuiteProcess.status)
+exit(testSuiteProcess.status ?? 1)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/BrowserStackCE/browserstack-side-runner.git"
   },
-  "version": "2.3.0",
+  "version": "2.4.0",
   "main": "index.mjs",
   "homepage": "https://github.com/BrowserStackCE/browserstack-side-runner#readme",
   "scripts": {


### PR DESCRIPTION
- SDK path was not working for npm deploy
- added utf8 encoding for string parsing
- removed path from sanitization